### PR TITLE
Add <Plug> mappings

### DIFF
--- a/doc/githubinator.txt
+++ b/doc/githubinator.txt
@@ -11,21 +11,35 @@ project exists.
 
 There are just a total of 3 requirements for this to work
 - You should be in the root of the project directory.
-- You have `open` command for gho
-- You have `pbcopy` command for ghc
+- You have `open` command for |<Plug>(githubinator-open)|
+- You have `pbcopy` command for |<Plug>(githubinator-copy)|
 
 
 =======================================================================
-USAGE
+MAPPINGS
 
-*gho*                     Open selected text on Github with the default
-                        browser using the `open` command if it is
-                        present, throws an error otherwise.
+*<Plug>(githubinator-open)*
+    Open selected text on Github with the default browser using the
+    `open` command if it is present, throws an error otherwise.
 
-*ghc*                     Same as gho except it doesn't open the browser
-                        but rather copies the said URL to the clipboard
-                        using pbcopy if it is present, throws an error
-                        otherwise.
+*<Plug>(githubinator-copy)*
+    Same as |<Plug>(githubinator-open)| except it doesn't open the
+    browser but rather copies the said URL to the clipboard using
+    pbcopy if it is present, throws an error otherwise.
+
+=======================================================================
+DEFAULT MAPPINGS
+
+{lhs}     {rhs} ~
+--------  --------------------------- ~
+*gho*     |<Plug>(githubinator-open)|
+*ghc*     |<Plug>(githubinator-copy)|
+
+=======================================================================
+OPTIONS
+
+*g:githubinator_no_default_mapping* (default: 0)
+    Disable the default mappings if the value is not 0.
 
 =======================================================================
 LICENSE

--- a/plugin/githubinator.vim
+++ b/plugin/githubinator.vim
@@ -33,9 +33,9 @@ function! GetRangeDelimiters() range
     let l:end = getpos("'>")[1]
 
     return [l:beg, l:end]
-endfunction 
+endfunction
 
-" get remote URL from .git/config 
+" get remote URL from .git/config
 function! s:generate_url() range
     if !isdirectory('.git')
         echoerr "githubinator: No .git directory found"
@@ -50,7 +50,7 @@ function! s:generate_url() range
     let l:final_url = l:git_remote . '/blob/' . l:branch . '/' . l:file_name . '#L' . l:beg . '-L' . l:end
 
     return l:final_url
-endfunction 
+endfunction
 
 function! GithubOpenURL() range
     let l:final_url = s:generate_url()
@@ -79,5 +79,10 @@ function! GithubCopyURL() range
     echom "Githubinator: URL copied to clipboard."
 endfunction
 
-vnoremap gho :call GithubOpenURL()<CR>
-vnoremap ghc :call GithubCopyURL()<CR>
+vnoremap <silent> <Plug>(githubinator-open) :<C-U>call GithubOpenURL()<CR>
+vnoremap <silent> <Plug>(githubinator-copy) :<C-U>call GithubCopyURL()<CR>
+
+if get(g:, 'githubinator_no_default_mapping', 0) == 0
+    vmap <silent> gho <Plug>(githubinator-open)
+    vmap <silent> ghc <Plug>(githubinator-copy)
+endif


### PR DESCRIPTION
This PR solves #6 .
- `<Plug>(githubinator-open)` and `<Plug>(githubinator-copy)` is added.
- If `g:githubinator_no_default_mapping`  is not 0, the default mappings (`gho`, `ghc`) are disabled.

Closes #6 