### PR TITLE
Refactor getting remote url 

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,18 +5,20 @@
 </p>
 
 ## What?
-This plugin helps you select some text in vim visually and then open it in Github with the selection highlighted. This was inspired from [Githubinator](https://github.com/ehamiter/GitHubinator) for sublime.
+This plugin helps you select some text in vim visually and then open it in Github or other remote repository with the selection highlighted.
+This was inspired from [Githubinator](https://github.com/ehamiter/GitHubinator) for sublime.
 
-## Commands
+## Default commands
 ```text
-gho:      Open selected text on Github with the default
-          browser using the `open` command if it is
-          present, throws an error otherwise.
-          
-ghc:      Same as gho except it doesn't open the browser
-          but rather copies the said URL to the clipboard
-          using pbcopy if it is present, throws an error
-          otherwise.
+gho
+    Open selected text on git remote repository with the default
+    browser using the `open` or `xdg-open` command if it is present,
+    throws an error otherwise.
+
+ghc
+    Same as gho except it doesn't open the
+    browser but rather copies the said URL to the clipboard using
+    pbcopy if it is present, throws an error otherwise.
 ```
 
 ## Installation

--- a/doc/githubinator.txt
+++ b/doc/githubinator.txt
@@ -31,8 +31,8 @@ DEFAULT MAPPINGS
 
 map {lhs}     {rhs} ~
 --- --------  --------------------------- ~
-v       *gho*     |<Plug>(githubinator-open)|
-v       *ghc*     |<Plug>(githubinator-copy)|
+x       *gho*     |<Plug>(githubinator-open)|
+x       *ghc*     |<Plug>(githubinator-copy)|
 
 =======================================================================
 OPTIONS

--- a/doc/githubinator.txt
+++ b/doc/githubinator.txt
@@ -6,21 +6,20 @@ License: MIT
 
 =======================================================================
 Githubinator is a nifty little plugin which allows you to open snippets
-of text inside your editor directly on Github if a remote repo for the
-project exists.
+of text inside your editor directly on remote repository if a remote
+repository for the project exists.
 
-There are just a total of 3 requirements for this to work
-- You should be in the root of the project directory.
-- You have `open` command for |<Plug>(githubinator-open)|
-- You have `pbcopy` command for |<Plug>(githubinator-copy)|
-
+There are just a total of 2 requirements for this to work
+- You have `open` or `xdg-open` command for |<Plug>(githubinator-open)|
+- You have `pbcopy` or `xsel` command for |<Plug>(githubinator-copy)|
 
 =======================================================================
 MAPPINGS
 
 *<Plug>(githubinator-open)*
-    Open selected text on Github with the default browser using the
-    `open` command if it is present, throws an error otherwise.
+    Open selected text on git remote repository with the default
+    browser using the `open` or `xdg-open` command if it is present,
+    throws an error otherwise.
 
 *<Plug>(githubinator-copy)*
     Same as |<Plug>(githubinator-open)| except it doesn't open the
@@ -30,10 +29,10 @@ MAPPINGS
 =======================================================================
 DEFAULT MAPPINGS
 
-{lhs}     {rhs} ~
---------  --------------------------- ~
-*gho*     |<Plug>(githubinator-open)|
-*ghc*     |<Plug>(githubinator-copy)|
+map {lhs}     {rhs} ~
+--- --------  --------------------------- ~
+v       *gho*     |<Plug>(githubinator-open)|
+v       *ghc*     |<Plug>(githubinator-copy)|
 
 =======================================================================
 OPTIONS
@@ -55,3 +54,4 @@ Thanks!
 Github:    https://github.com/prakashdanish/vim-githubinator
 
 =======================================================================
+vim:tw=78:ts=8:ft=help:norl:noet:fen:

--- a/plugin/githubinator.vim
+++ b/plugin/githubinator.vim
@@ -46,9 +46,20 @@ function! s:generate_url()
     " In order to support relative filepath, convert full path and remove the git root path in it.
     let l:file_name = expand('%:p')[len(root_dir) : -1]
     let [l:beg, l:end] = s:get_range_delimiters()
-    let l:branch = system("git name-rev --name-only HEAD | tr -d '\n'")
-    let l:remote = system("git config remote.origin.url | sed -Ee 's!(git@|git://)!https://!' -e 's!:([^/])!/\\1!' -e 's!\.git$!!' | tr -d '\n'")
 
+    " Remove `tags/`.
+    let l:branch = system('git name-rev --name-only HEAD')
+    let l:branch = substitute(l:branch, '^tags//\|\n', '', '')
+
+    " Change URL scheme to https.
+    " Remove `.git` and newline.
+    " Change `:` to `/` (in case of ssh remote).
+    let l:remote = system('git config remote.origin.url')
+    let l:remote = substitute(l:remote, 'git@\|git:', 'https://', 'g')
+    let l:remote = substitute(l:remote, '\.git.$', '', '')
+    let l:remote = substitute(l:remote, ':\([^/]\)', '/\1', 'g')
+
+    " Build final URL.
     return printf('%s/blob/%s/%s#L%d-L%d', l:remote, l:branch, l:file_name, l:beg, l:end)
 endfunction
 

--- a/plugin/githubinator.vim
+++ b/plugin/githubinator.vim
@@ -90,8 +90,8 @@ function! s:github_copy_url()
     echom 'Githubinator: URL copied to clipboard.'
 endfunction
 
-vnoremap <silent> <Plug>(githubinator-open) :<C-U>call <SID>github_open_url()<CR>
-vnoremap <silent> <Plug>(githubinator-copy) :<C-U>call <SID>github_copy_url()<CR>
+xnoremap <silent> <Plug>(githubinator-open) :<C-U>call <SID>github_open_url()<CR>
+xnoremap <silent> <Plug>(githubinator-copy) :<C-U>call <SID>github_copy_url()<CR>
 
 if get(g:, 'githubinator_no_default_mapping', 0) == 0
     vmap <silent> gho <Plug>(githubinator-open)


### PR DESCRIPTION
## Description
This PR solves #3, #5 and #11 .
I will create another PR to handle multiple remote.

## Features
- Support subdirectory.
- Support any git remote URL (e.g., https, GitHub Enterprise)

## How to check this PR changes
Suppose the condition below
```console
$HOME/repos/vim-githubinator

.
├── README.md
├── doc
│   └── githubinator.txt
└── plugin
    └── githubinator.vim
```

You can use this plugin at NOT git root.
* Open `githubinator.txt` at `doc` directory
* Select some lines, and type `gho`.
* Open Github page.

You can use this plugin if vim opens file via relative path.
* Open `githubinator.vim` at `githubinator.txt`.
* Select some lines, and type `gho`.
* Open Github page.