### PR TITLE
Support subdirector in the git repo and add normal mapping, command.

### DIFF
--- a/doc/githubinator.txt
+++ b/doc/githubinator.txt
@@ -21,25 +21,41 @@ MAPPINGS
 *<Plug>(githubinator-open)*
     Open selected text on Github with the default browser using the
     `open` command if it is present, throws an error otherwise.
+    Normal mapping accept a number to select the lines. 
 
 *<Plug>(githubinator-copy)*
     Same as |<Plug>(githubinator-open)| except it doesn't open the
     browser but rather copies the said URL to the clipboard using
     pbcopy if it is present, throws an error otherwise.
+    Normal mapping accept a number to select the lines. 
+
+If you don't define mapping, it will use the default mappings.
 
 =======================================================================
 DEFAULT MAPPINGS
 
-{lhs}     {rhs} ~
---------  --------------------------- ~
-*gho*     |<Plug>(githubinator-open)|
-*ghc*     |<Plug>(githubinator-copy)|
+{mode}  {lhs}     {rhs} ~
+------ --------  --------------------------- ~
+vn     *gho*     |<Plug>(githubinator-open)|
+vn     *ghc*     |<Plug>(githubinator-copy)|
 
 =======================================================================
-OPTIONS
+COMMAND
+*GHO*
+    Same as |<Plug>(githubinator-open)|
+    It accept a range number to select the lines. 
+eg: >
+3,5GHO
+.,+1GHO
+<
 
-*g:githubinator_no_default_mapping* (default: 0)
-    Disable the default mappings if the value is not 0.
+*GHC*
+    Same as |<Plug>(githubinator-copy)|
+    It accept a range number to select the lines. 
+eg: >
+3,5GHC
+.,+1GHO
+<
 
 =======================================================================
 LICENSE
@@ -55,3 +71,5 @@ Thanks!
 Github:    https://github.com/prakashdanish/vim-githubinator
 
 =======================================================================
+
+" vim:ft=help:iskeyword+=-:iskeyword+=58:iskeyword+=#"


### PR DESCRIPTION
1. Support subdirector
Get the subdirector relative to git repo and add to the url.
2. Support https protocol
Before this commit, the parsed url of https protocol is invalid.

For example:
```
git clone https://github.com/ehamiter/GitHubinator.git
vim README.md
```
Execute `<s-v>gho`

The parse url is `https://github.com///github.com/prakashdanish/vim-githubinator/blob/master/README.md#L1`

3. Add normal mappings

4. Add commands
Add `GHO` `GHC` command to open or copy the url.

close #5