### PR TITLE
Restore normal mode mapping

### DIFF
--- a/doc/githubinator.txt
+++ b/doc/githubinator.txt
@@ -31,8 +31,10 @@ DEFAULT MAPPINGS
 
 map {lhs}     {rhs} ~
 --- --------  --------------------------- ~
-x       *gho*     |<Plug>(githubinator-open)|
-x       *ghc*     |<Plug>(githubinator-copy)|
+n       *gho*     |<Plug>(githubinator-open)|
+v       *gho*     |<Plug>(githubinator-open)|
+n       *ghc*     |<Plug>(githubinator-copy)|
+v       *ghc*     |<Plug>(githubinator-copy)|
 
 =======================================================================
 OPTIONS

--- a/doc/githubinator.txt
+++ b/doc/githubinator.txt
@@ -31,10 +31,8 @@ DEFAULT MAPPINGS
 
 map {lhs}     {rhs} ~
 --- --------  --------------------------- ~
-n       *gho*     |<Plug>(githubinator-open)|
-v       *gho*     |<Plug>(githubinator-open)|
-n       *ghc*     |<Plug>(githubinator-copy)|
-v       *ghc*     |<Plug>(githubinator-copy)|
+nv       *gho*     |<Plug>(githubinator-open)|
+nv       *ghc*     |<Plug>(githubinator-copy)|
 
 =======================================================================
 OPTIONS

--- a/plugin/githubinator.vim
+++ b/plugin/githubinator.vim
@@ -77,17 +77,8 @@ endfunction
 
 function! s:github_copy_url(mode)
     let l:final_url = s:generate_url(a:mode)
-
-    if executable('pbcopy')
-        call system('echo ' . l:final_url . ' | pbcopy')
-    elseif executable('xsel')
-        call system('echo ' . l:final_url . ' | xsel -b')
-    else
-        echoerr 'githubinator: no `copy-to-clipboard` command found.'
-        return
-    endif
-
-    echom 'Githubinator: URL copied to clipboard: ' . l:final_url
+    let @+ = l:final_url
+    echom 'Githubinator: URL copied to clipboard ' . l:final_url
 endfunction
 
 vnoremap <silent> <Plug>(githubinator-open) :<C-U>call <SID>github_open_url('v')<CR>

--- a/plugin/githubinator.vim
+++ b/plugin/githubinator.vim
@@ -34,8 +34,8 @@ function! s:get_range_delimiters()
 
     " if we aren't in a visual selection, then just get the row number
     if l:end == 0 && l:beg == 0
-      let l:end = getpos(".")[1]
-      let l:beg = l:end
+        let l:end = getpos('.')[1]
+        let l:beg = l:end
     endif
 
     return [l:beg, l:end]
@@ -62,10 +62,8 @@ function! s:generate_url()
     " Change `:` to `/` (in case of ssh remote).
     let l:remote = system('git config remote.origin.url')
     let l:remote = substitute(l:remote, 'git@\|git:', 'https://', 'g')
-    let l:remote = substitute(l:remote, '\.git.$', '', '')
-    echom string(l:remote)
+    let l:remote = substitute(l:remote, '\.git.$\|\n', '', '')
     let l:remote = substitute(l:remote, ':\([^/]\)', '/\1', 'g')
-    echom string(l:remote)
 
     " Build final URL.
     return printf('%s/blob/%s/%s#L%d-L%d', l:remote, l:branch, l:file_name, l:beg, l:end)

--- a/plugin/githubinator.vim
+++ b/plugin/githubinator.vim
@@ -32,6 +32,12 @@ function! s:get_range_delimiters()
     let l:beg = getpos("'<")[1]
     let l:end = getpos("'>")[1]
 
+    " if we aren't in a visual selection, then just get the row number
+    if l:end == 0 && l:beg == 0
+      let l:end = getpos(".")[1]
+      let l:beg = l:end
+    endif
+
     return [l:beg, l:end]
 endfunction
 
@@ -94,8 +100,13 @@ endfunction
 
 vnoremap <silent> <Plug>(githubinator-open) :<C-U>call <SID>github_open_url()<CR>
 vnoremap <silent> <Plug>(githubinator-copy) :<C-U>call <SID>github_copy_url()<CR>
+noremap <silent> <Plug>(githubinator-open) :<C-U>call <SID>github_open_url()<CR>
+noremap <silent> <Plug>(githubinator-copy) :<C-U>call <SID>github_copy_url()<CR>
 
 if get(g:, 'githubinator_no_default_mapping', 0) == 0
     vmap <silent> gho <Plug>(githubinator-open)
     vmap <silent> ghc <Plug>(githubinator-copy)
+
+    nmap <silent> gho <Plug>(githubinator-open)
+    nmap <silent> ghc <Plug>(githubinator-copy)
 endif

--- a/plugin/githubinator.vim
+++ b/plugin/githubinator.vim
@@ -78,7 +78,7 @@ endfunction
 function! s:github_copy_url(mode)
     let l:final_url = s:generate_url(a:mode)
     let @+ = l:final_url
-    echom 'Githubinator: URL copied to clipboard ' . l:final_url
+    echom 'Githubinator: URL copied to clipboard'
 endfunction
 
 vnoremap <silent> <Plug>(githubinator-open) :<C-U>call <SID>github_open_url('v')<CR>


### PR DESCRIPTION
Hi

I found the commit https://github.com/danishprakash/vim-githubinator/commit/da9a32746b6ff0918dbbc3544e0b535487f94178 drops the normal mode mappings.
This PR then restores it.

In addition, removing newline is not enough.
Regexp to remove it is also added.